### PR TITLE
Fixes bug when trying to run iCalBuddy from other applications

### DIFF
--- a/icalBuddyFunctions.m
+++ b/icalBuddyFunctions.m
@@ -624,7 +624,7 @@ void filterCalendars(NSMutableArray *cals, AppOptions *opts)
 
 NSArray *getCalendars(AppOptions *opts)
 {
-    NSMutableArray *calendars = [[[[CALENDAR_STORE defaultCalendarStore] calendars] mutableCopy] autorelease];
+    NSMutableArray *calendars = [[[[[[CALENDAR_STORE alloc] init] autorelease] calendars] mutableCopy] autorelease];
     filterCalendars(calendars, opts);
     return calendars;
 }


### PR DESCRIPTION
This change fixes a bug which caused iCalBuddy to return "no calendars" when trying to run it using other applications - LaunchControl, Keyboard Maestro, Etc.


Thanks to TJ Luoma for bringing this to my attention.
This was actually fixed by Robby Pählig, developer of LaunchControl - not by me.

Robby's message to TJ about this was this:
"I would not call it a proper fix because I don't know if it works for the built-in test suite or on other versions of macOS."

Some discussion here: https://forum.keyboardmaestro.com/t/icalbuddy-doesnt-work-within-keyboard-maestro-mojave-calendar-permissions/15446/13

