### PR TITLE
Add bexelbie's -oa / --onlyAllDayEvents, doc, usage

### DIFF
--- a/icalBuddy.m
+++ b/icalBuddy.m
@@ -230,6 +230,7 @@ int main(int argc, char *argv[])
                @"-nrd        No relative dates\n"
                @"-npn        No property names\n"
                @"-n          Include only events from now on\n"
+               @"-oa         Only output all-day events\n"
                @"-sed        Show empty dates\n"
                @"-uid        Show event/task UIDs\n"
                @"-eed        Exclude end datetimes\n"

--- a/icalBuddy.pod
+++ b/icalBuddy.pod
@@ -132,6 +132,10 @@ Omit property names from the output (i.e. only show property values -- e.g. "My 
 
 If the I<command> value C<eventsToday> is used, only output events that occur between the current time and the end of the day (as opposed to events that occur between the start and end of the day, as by default.)
 
+=item B<-oa>, B<--onlyAllDayEvents>
+
+Only output all-day events.
+
 =item B<-na>, B<--maxNumAttendees>
 
 Maximum number of attendees to show for events.

--- a/icalBuddyArgs.m
+++ b/icalBuddyArgs.m
@@ -77,6 +77,8 @@ void handleArgument(NSString *shortName, NSString *longName, id value,
             opts->alwaysShowTodaysSection = YES;
         else if ([shortName isEqualToString:@"ea"] || [longName isEqualToString:@"excludeAllDayEvents"])
             opts->excludeAllDayEvents = YES;
+        else if ([shortName isEqualToString:@"oa"] || [longName isEqualToString:@"onlyAllDayEvents"])
+            opts->onlyAllDayEvents = YES;
     }
 
     // value-requiring arguments

--- a/icalBuddyDefines.h
+++ b/icalBuddyDefines.h
@@ -144,6 +144,7 @@ typedef struct
     BOOL alwaysShowTodaysSection;
     BOOL specificCalFilterPrecedesCalTypeFilter;
     BOOL excludeAllDayEvents;
+    BOOL onlyAllDayEvents;
 
     BOOL output_is_uncompletedTasks;
     BOOL output_is_eventsToday;
@@ -171,7 +172,7 @@ typedef struct
     NSUInteger maxNumNoteCharacters;
 } AppOptions;
 
-#define NEW_DEFAULT_APP_OPTIONS {NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,\
+#define NEW_DEFAULT_APP_OPTIONS {NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,NO,\
                                  nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,nil,0,0}
 
 

--- a/icalBuddyFunctions.m
+++ b/icalBuddyFunctions.m
@@ -134,6 +134,9 @@ NSArray *getEvents(AppOptions *opts, NSArray *calendars)
     if (opts->excludeAllDayEvents)
         ret = [ret filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isAllDay == NO"]];
 
+    if (opts->onlyAllDayEvents)
+        ret = [ret filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isAllDay == YES"]];
+
     return ret;
 }
 


### PR DESCRIPTION
This incorporates @bexelbie's -oa / --onlyAllDayEvents flag from another fork. 
It also adds -oa to the usage statement and to the docs. 

-oa / --onlyAllDayEvents, as the long form suggests, will only output all-day events.
