### PR TITLE
Remove -force_cpusubtype_ALL flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ icalBuddy: $(SOURCE_FILES) icalBuddy.m
 	@echo
 	@echo ---- Compiling main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch x86_64 -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 $(CC_WARN_OPTS) -std=c99 -mmacosx-version-min=10.5  -arch x86_64 -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m $(SOURCE_FILES)
 
 
 
@@ -54,7 +54,7 @@ testIcalBuddy: $(SOURCE_FILES) icalBuddy.m calendarStoreMock/*.m
 	@echo
 	@echo ---- Compiling TEST version of main app:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5  -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -mmacosx-version-min=10.5  -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ icalBuddy.m calendarStoreMock/*.m $(SOURCE_FILES)
 
 
 
@@ -81,7 +81,7 @@ testRunner: $(SOURCE_FILES)
 	@echo
 	@echo ---- Compiling test runner:
 	@echo ======================================
-	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -force_cpusubtype_ALL -mmacosx-version-min=10.5 -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
+	$(COMPILER) $(ARG_DEBUG) -O3 -Wall -std=c99 -mmacosx-version-min=10.5 -arch x86_64 -DUSE_MOCKED_CALENDARSTORE -framework Cocoa -framework CalendarStore -framework AppKit -framework AddressBook -o $@ testRunner.m $(SOURCE_FILES) calendarStoreMock/*.m tests/unit/*.m
 
 
 


### PR DESCRIPTION
When trying to build `icalBuddy` with Xcode 15's toolchain on macOS Sonoma, it fails with:

```
ld: unknown options: -force_cpusubtype_ALL
```

`-force_cpusubtype_ALL` is only relevant when building for PowerPC and is no longer allowed in Xcode 15.

